### PR TITLE
FIX: wrap tags assignment with DB transaction

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -17,8 +17,11 @@ after_initialize do
       topic.tags ||= []
 
       unless topic.tags.pluck(:id).include?(tag.id)
-        topic.tags << tag
-        topic.save
+        ActiveRecord::Base.transaction do
+          topic.tags.reload
+          topic.tags << tag
+          topic.save
+        end
 
         post.publish_change_to_clients!(:revised, reload_topic: true)
       end


### PR DESCRIPTION
There are 2 plugins that are modifying tags almost at the same moment as :topic_created and :post_created events are triggered at the same moment.

Therefore, they can have conflict and one can destroy the effect of another
https://github.com/discourse/discourse-tag-topic-user-device
https://github.com/discourse/discourse-unhandled-tagger

The transaction should prevent that from happening.

Corresponding PR https://github.com/discourse/discourse-tag-topic-user-device/pull/2