### PR TITLE
FEATURE: Add verbose logging for unhandled tag changes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,3 +3,6 @@ plugins:
     default: 'unhandled'
     client: true
     hidden: true
+  verbose_discourse_unhandled_tagger_logging:
+    default: false
+    hidden: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,27 +17,30 @@ after_initialize do
     unless topic.tags.exists?(id: tag.id)
       topic.tags << tag
       if SiteSetting.verbose_discourse_unhandled_tagger_logging
-        Rails.logger.warn("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+        Rails.logger.warn(
+          "Verbose Unhandled Tagger Log: tag added to topic: #{topic.id}, post: #{post.id} by plugin",
+        )
       end
     end
   end
 
   on(:post_edited) do |post, _, revisor|
     next if SiteSetting.unhandled_tag.blank?
+    next if post.topic.private_message?
     next unless SiteSetting.verbose_discourse_unhandled_tagger_logging
     next unless revisor.topic_tags_changed?
 
     if revisor.topic_diff["tags"][0].exclude?(SiteSetting.unhandled_tag) &&
          revisor.topic_diff["tags"][1].include?(SiteSetting.unhandled_tag)
       Rails.logger.warn(
-        "Verbose Unhandled Tagger Log: tag added to topic #{post.topic_id} by #{revisor.guardian.user.username}",
+        "Verbose Unhandled Tagger Log: tag added to topic: #{post.topic_id}, post: #{post.id} by #{revisor.guardian.user.username}",
       )
     end
 
     if revisor.topic_diff["tags"][1].exclude?(SiteSetting.unhandled_tag) &&
          revisor.topic_diff["tags"][0].include?(SiteSetting.unhandled_tag)
       Rails.logger.warn(
-        "Verbose Unhandled Tagger Log: tag removed from topic #{post.topic_id} by #{revisor.guardian.user.username}",
+        "Verbose Unhandled Tagger Log: tag removed from topic: #{post.topic_id}, post: #{post.id} by #{revisor.guardian.user.username}",
       )
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,6 +14,31 @@ after_initialize do
     tag = Tag.find_or_create_by!(name: SiteSetting.unhandled_tag)
     topic = post.topic
 
-    topic.tags << tag unless topic.tags.exists?(id: tag.id)
+    unless topic.tags.exists?(id: tag.id)
+      topic.tags << tag
+      if SiteSetting.verbose_discourse_unhandled_tagger_logging
+        Rails.logger.warn("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+      end
+    end
+  end
+
+  on(:post_edited) do |post, _, revisor|
+    next if SiteSetting.unhandled_tag.blank?
+    next unless SiteSetting.verbose_discourse_unhandled_tagger_logging
+    next unless revisor.topic_tags_changed?
+
+    if revisor.topic_diff["tags"][0].exclude?(SiteSetting.unhandled_tag) &&
+         revisor.topic_diff["tags"][1].include?(SiteSetting.unhandled_tag)
+      Rails.logger.warn(
+        "Verbose Unhandled Tagger Log: tag added to topic #{post.topic_id} by #{revisor.guardian.user.username}",
+      )
+    end
+
+    if revisor.topic_diff["tags"][1].exclude?(SiteSetting.unhandled_tag) &&
+         revisor.topic_diff["tags"][0].include?(SiteSetting.unhandled_tag)
+      Rails.logger.warn(
+        "Verbose Unhandled Tagger Log: tag removed from topic #{post.topic_id} by #{revisor.guardian.user.username}",
+      )
+    end
   end
 end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -86,6 +86,92 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
     expect(topic.tags.reload.pluck(:name)).to contain_exactly("unhandled")
   end
 
+  context "with verbose logging enabled" do
+    fab!(:user)
+    fab!(:admin)
+
+    before { SiteSetting.verbose_discourse_unhandled_tagger_logging = true }
+
+    it "logs when the plugin adds the unhandled tag" do
+      Rails
+        .logger
+        .expects(:warn)
+        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+
+      PostCreator.create!(user, topic_id: topic.id, raw: "this is a test reply")
+    end
+
+    it "does not log when the tag already exists on the topic" do
+      PostCreator.create!(user, topic_id: topic.id, raw: "this is a test reply")
+
+      Rails
+        .logger
+        .expects(:warn)
+        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+        .never
+
+      PostCreator.create!(user, topic_id: topic.id, raw: "this is another reply")
+    end
+
+    it "logs when a user adds the unhandled tag via editing" do
+      post = PostCreator.create!(admin, topic_id: topic.id, raw: "this is a test reply")
+
+      Rails
+        .logger
+        .expects(:warn)
+        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by #{admin.username}")
+
+      PostRevisor.new(post, topic).revise!(admin, { tags: ["unhandled"] }, validate_post: false)
+    end
+
+    it "logs when a user removes the unhandled tag via editing" do
+      DiscourseTagging.tag_topic_by_names(
+        topic,
+        Discourse.system_user.guardian,
+        %w[unhandled other],
+      )
+      post = PostCreator.create!(admin, topic_id: topic.id, raw: "this is a test reply")
+
+      Rails
+        .logger
+        .expects(:warn)
+        .with(
+          "Verbose Unhandled Tagger Log: tag removed from topic #{topic.id} by #{admin.username}",
+        )
+
+      PostRevisor.new(post, topic).revise!(admin, { tags: ["other"] }, validate_post: false)
+    end
+  end
+
+  context "with verbose logging disabled" do
+    fab!(:user)
+    fab!(:admin)
+
+    before { SiteSetting.verbose_discourse_unhandled_tagger_logging = false }
+
+    it "does not log when the plugin adds the unhandled tag" do
+      Rails
+        .logger
+        .expects(:warn)
+        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+        .never
+
+      PostCreator.create!(user, topic_id: topic.id, raw: "this is a test reply")
+    end
+
+    it "does not log when a user edits tags" do
+      post = PostCreator.create!(admin, topic_id: topic.id, raw: "this is a test reply")
+
+      Rails
+        .logger
+        .expects(:warn)
+        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by #{admin.username}")
+        .never
+
+      PostRevisor.new(post, topic).revise!(admin, { tags: ["unhandled"] }, validate_post: false)
+    end
+  end
+
   context "with category tag restrictions" do
     fab!(:tag_group) { Fabricate(:tag_group, name: "Category Tags") }
     fab!(:windows_tag) { Fabricate(:tag, name: "windows") }

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -96,7 +96,11 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
       Rails
         .logger
         .expects(:warn)
-        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+        .with do |msg|
+          msg.match?(
+            /Verbose Unhandled Tagger Log: tag added to topic: #{topic.id}, post: \d+ by plugin/,
+          )
+        end
 
       PostCreator.create!(user, topic_id: topic.id, raw: "this is a test reply")
     end
@@ -107,7 +111,11 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
       Rails
         .logger
         .expects(:warn)
-        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+        .with do |msg|
+          msg.match?(
+            /Verbose Unhandled Tagger Log: tag added to topic: #{topic.id}, post: \d+ by plugin/,
+          )
+        end
         .never
 
       PostCreator.create!(user, topic_id: topic.id, raw: "this is another reply")
@@ -119,7 +127,11 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
       Rails
         .logger
         .expects(:warn)
-        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by #{admin.username}")
+        .with do |msg|
+          msg.match?(
+            /Verbose Unhandled Tagger Log: tag added to topic: #{topic.id}, post: \d+ by #{admin.username}/,
+          )
+        end
 
       PostRevisor.new(post, topic).revise!(admin, { tags: ["unhandled"] }, validate_post: false)
     end
@@ -135,9 +147,11 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
       Rails
         .logger
         .expects(:warn)
-        .with(
-          "Verbose Unhandled Tagger Log: tag removed from topic #{topic.id} by #{admin.username}",
-        )
+        .with do |msg|
+          msg.match?(
+            /Verbose Unhandled Tagger Log: tag removed from topic: #{topic.id}, post: \d+ by #{admin.username}/,
+          )
+        end
 
       PostRevisor.new(post, topic).revise!(admin, { tags: ["other"] }, validate_post: false)
     end
@@ -153,7 +167,11 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
       Rails
         .logger
         .expects(:warn)
-        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by plugin")
+        .with do |msg|
+          msg.match?(
+            /Verbose Unhandled Tagger Log: tag added to topic: #{topic.id}, post: \d+ by plugin/,
+          )
+        end
         .never
 
       PostCreator.create!(user, topic_id: topic.id, raw: "this is a test reply")
@@ -165,7 +183,11 @@ describe "discourse-unhandled-tagger" do # rubocop:disable RSpec/DescribeClass
       Rails
         .logger
         .expects(:warn)
-        .with("Verbose Unhandled Tagger Log: tag added to topic #{topic.id} by #{admin.username}")
+        .with do |msg|
+          msg.match?(
+            /Verbose Unhandled Tagger Log: tag added to topic: #{topic.id}, post: \d+ by #{admin.username}/,
+          )
+        end
         .never
 
       PostRevisor.new(post, topic).revise!(admin, { tags: ["unhandled"] }, validate_post: false)


### PR DESCRIPTION
When investigating issues with the unhandled tag being unexpectedly added or removed from topics, there is no way to determine whether the plugin itself applied the tag or a user manually changed it. It is because we are not creating PostRevision records for hidden tags. This makes it difficult to debug tagging behaviour in production.

This PR adds a hidden `verbose_discourse_unhandled_tagger_logging` site setting (off by default) that, when enabled, logs whenever the unhandled tag is added or removed. The logging covers two paths:

- The `post_created` event handler logs when the plugin automatically adds the tag to a topic.
- A new `post_edited` event handler logs when a user manually adds or removes the unhandled tag.